### PR TITLE
TexFormatType visibility change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 
-pub use self::format::{Format, Swizzle, Swizzles};
+pub use self::format::{Format, Swizzle, Swizzles, TexFormatType};
 pub use self::extent::{Extent1d, Extent2d, Extent3d};
 
 pub use self::image::GliImage;


### PR DESCRIPTION
The function load_from_memory is not usable without TexFormatType, which isn't visible outside of the crate.